### PR TITLE
[Bug] Backend의 Docker가 빌드되지 않는 문제 해결

### DIFF
--- a/backend/Resume-And-Portfolio/Dockerfile
+++ b/backend/Resume-And-Portfolio/Dockerfile
@@ -6,6 +6,8 @@ COPY gradlew /app/gradlew
 COPY build.gradle /app/build.gradle
 COPY settings.gradle /app/settings.gradle
 
+RUN chmod +x gradlew
+
 RUN ./gradlew dependencies --no-daemon
 
 COPY . .


### PR DESCRIPTION
## 💡 이슈
- related to #4 

## 🤩 개요
Backend의 Docker가 빌드되지 않는 문제 해결

## 🧑‍💻 작업 사항
- Backend Dockerfile에서 gradlew 실행 권한 추가