### PR TITLE
[Bug] 배포된 API 테스트 중 Unable to connect to Redis 문제 발생

### DIFF
--- a/backend/Resume-And-Portfolio/src/main/java/com/example/resumeandportfolio/config/RedisConfig.java
+++ b/backend/Resume-And-Portfolio/src/main/java/com/example/resumeandportfolio/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -29,9 +30,12 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        LettuceConnectionFactory factory = new LettuceConnectionFactory(redisHost, redisPort);
-        factory.setPassword(redisPassword);
-        return factory;
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisHost);
+        config.setPort(redisPort);
+        config.setPassword(redisPassword);
+
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean


### PR DESCRIPTION
## 💡 이슈
- related to #38 

## 🤩 개요
Postman으로 로그인 API 테스트 중 Unable to connect to Redis 오류 해결

## 🧑‍💻 작업 사항
1. 기존의 RedisConfig에서  Spring 애플리케이션과 Redis 서버 간의 연결을 생성하고 관리하는 redisConnectionFactory 메서드가 deprecated한 방법으로 비밀번호를 설정하고 있었음.
2. 최신 버전에 맞게 redisConnectionFactory 메서드 구성 변경.