### PR TITLE
[Bug] EC2로 배포된 페이지에서 로그인 안됨

### DIFF
--- a/backend/Resume-And-Portfolio/src/main/java/com/example/resumeandportfolio/controller/user/OAuth2Controller.java
+++ b/backend/Resume-And-Portfolio/src/main/java/com/example/resumeandportfolio/controller/user/OAuth2Controller.java
@@ -20,7 +20,7 @@ public class OAuth2Controller {
     // Google 인증 URL로 리다이렉트
     @GetMapping("/google")
     public void redirectToGoogleOAuth(HttpServletResponse response) throws IOException {
-        String redirectUrl = "/oauth2/authorization/google";
+        String redirectUrl = "https://www.jsw-resumeandportfolio.com/oauth2/authorization/google";
         response.sendRedirect(redirectUrl);
     }
 }


### PR DESCRIPTION
## 💡 이슈
- related to #44 

## 🤩 개요
EC2로 배포된 페이지에서 로그인 안되는 문제 해결

## 🧑‍💻 작업 사항
1. 로그인 API 자체는 성공하는 듯 보이나 웹에서 사진과 같은 오류가 뜸. OAuth2에서 HTTP로 Redirect 하여 HTTP와 HTTPS가 혼용 되는 것이 문제로 보임.

![image](https://github.com/user-attachments/assets/46d59101-a7b4-45f6-b9d9-afd154c5a23f)
![image](https://github.com/user-attachments/assets/c7c5ad3a-67ad-41f7-a4c3-3aa8502c3b02)

2. OAuth2Controller에서 Redirect 할 때 HTTPS를 사용하도록 URI 값을 수정함.