### PR TITLE
[Bug] 소셜 로그인 리디렉션 오류

### DIFF
--- a/backend/Resume-And-Portfolio/src/main/java/com/example/resumeandportfolio/config/SecurityConfig.java
+++ b/backend/Resume-And-Portfolio/src/main/java/com/example/resumeandportfolio/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
                     authorization.baseUri("/api/users/oauth2/authorization")
                 )
                 .redirectionEndpoint(redirection ->
-                    redirection.baseUri("/oauth2/callback/*")
+                    redirection.baseUri("/api/users/oauth2/callback/*")
                 )
                 .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                 .successHandler(oAuth2AuthenticationSuccessHandler)


### PR DESCRIPTION
## 💡 이슈
- related to #58 

## 🤩 개요
소셜 로그인 리디렉션 오류
![image](https://github.com/user-attachments/assets/4dfa333f-23f3-4ca0-8314-57aa6d682989)

## 🧑‍💻 작업 사항
리디렉션 URI를 /api/users를 통하도록 설정. Security Filter Chain의 리디렉션 URI는 Authorization Code를 백엔드로 전달할 URL을 정의하는 역할을 하므로 백엔드로 설정함. 대신에 기존의 OAuth2AuthenticationSuccessHandler는 프론트로 리디렉션하도록 유지하여 JWT를 재발급 받게 함.