### PR TITLE
[Bug] 소셜 로그인 리디렉션 오류

### DIFF
--- a/frontend/my-app/src/components/Social-Login/OAuthRedirectHandler.js
+++ b/frontend/my-app/src/components/Social-Login/OAuthRedirectHandler.js
@@ -1,5 +1,5 @@
-import React, { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import React, {useEffect} from "react";
+import {useLocation, useNavigate} from "react-router-dom";
 import axios from "axios";
 
 function OAuthRedirectHandler() {
@@ -15,10 +15,7 @@ function OAuthRedirectHandler() {
       axios
       .post(
           "https://www.jsw-resumeandportfolio.com/api/users/oauth2/token",
-          null,
-          {
-            params: { code: oneTimeCode },
-          }
+          {code: oneTimeCode}
       )
       .then((response) => {
         const accessToken = response.data.accessToken;


### PR DESCRIPTION
## 💡 이슈
- related to #58 

## 🤩 개요
소셜 로그인 리디렉션 오류
![image](https://github.com/user-attachments/assets/2b607b1d-afb8-4c57-b00b-a413d0f82c87)

## 🧑‍💻 작업 사항
404가 뜨며 안됨. -> Postman에서 URL의 일회용 토큰을 이용하여 토큰 재발급 API를 실행하니 성공적으로 작동함. -> URL 창을 보니 FE의 OAuthRedirectHandler.js에서 GET 요청으로 작동하는 것이 의심됨.

params를 사용하면 GET 요청처럼 동작할 가능성이 있음. Axios에서 params는 쿼리 스트링을 추가하는 옵션임. 즉, 현재 코드에서 params를 사용하면 다음과 같이 URL에 ?code=xxx가 추가된 GET 요청이 보내질 가능성이 있음. 따라서, params 대신 data로 code 값을 전달해야 함.